### PR TITLE
Update URL to ACT-R 7 (not next branch/subfolder)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod 777 run-jupyter.sh && mv run-jupyter.sh /run-jupyter.sh
 
 USER ${NB_USER}
 
-RUN wget http://act-r.psy.cmu.edu/actr7.x/next/actr7.container.zip && \
+RUN wget http://act-r.psy.cmu.edu/actr7.x/actr7.container.zip && \
     unzip actr7.container.zip  && \
     rm -r actr7.container.zip
 


### PR DESCRIPTION
In the DockerFile, the URL to ACT-R 7 container version seems incorrect 
`http://act-r.psy.cmu.edu/actr7.x/next/actr7.container.zip` 
and I've updated it with 
`http://act-r.psy.cmu.edu/actr7.x/actr7.container.zip` 
which seems to be correct (or at least it doesn't 404). 