### PR TITLE
Copy tutorial instead of move

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN mv run-node.sh actr7.x/
 RUN rm README.md
 RUN rm Dockerfile
 
-RUN mv actr7.x/tutorial actr7.x/original-tutorial
+RUN cp -r actr7.x/tutorial actr7.x/original-tutorial
 
 RUN sbcl --quit --load quicklisp/setup.lisp --eval '(push :standalone *features*)' --load actr7.x/load-act-r.lisp
 


### PR DESCRIPTION
Got an error when tutorial wasn’t where it was originally. Possibly another script is attempting to copy or move after its already been moved. I'm not sure it should work this way only that it, coupled with #5  resolved my issue, #6 .